### PR TITLE
bump Node to v12 minimum as the current maintenance release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "server"
     ],
     "engines": {
-        "node": "10.*",
+        "node": "12.*",
         "npm": "6.*"
     },
     "nodemonConfig": {


### PR DESCRIPTION
Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>

According to https://nodejs.org/en/about/releases/ v12 is the current release.

Noticed via the js13kserver from js13kGames org (which is on v8 vs the v10 here).
I got deferred to GitHub PRs: https://twitter.com/AndreJaenisch/status/1429085863854673925

I tested using NVM (node v12.22.3 and npm v6.14.13) and observed no change in package-lock.json.